### PR TITLE
Use RequiredArgsConstrutor on Components

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/com/fernandakipper/desafioanotaai/controllers/CategoryController.java
+++ b/src/main/java/com/fernandakipper/desafioanotaai/controllers/CategoryController.java
@@ -3,20 +3,24 @@ package com.fernandakipper.desafioanotaai.controllers;
 import com.fernandakipper.desafioanotaai.domain.category.Category;
 import com.fernandakipper.desafioanotaai.domain.category.CategoryDTO;
 import com.fernandakipper.desafioanotaai.services.CategoryService;
-import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/category")
 public class CategoryController {
-    private CategoryService service;
-
-    public CategoryController(CategoryService service){
-        this.service = service;
-    }
+    private final CategoryService service;
 
     @PostMapping
     public ResponseEntity<Category> insert(@RequestBody CategoryDTO categoryData){

--- a/src/main/java/com/fernandakipper/desafioanotaai/controllers/ProductController.java
+++ b/src/main/java/com/fernandakipper/desafioanotaai/controllers/ProductController.java
@@ -3,20 +3,25 @@ package com.fernandakipper.desafioanotaai.controllers;
 import com.fernandakipper.desafioanotaai.domain.product.Product;
 import com.fernandakipper.desafioanotaai.domain.product.ProductDTO;
 import com.fernandakipper.desafioanotaai.services.ProductService;
-import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/product")
 public class ProductController {
-    private ProductService service;
+    private final ProductService service;
 
-    public ProductController(ProductService service){
-        this.service = service;
-    }
 
     @PostMapping
     public ResponseEntity<Product> insert(@RequestBody ProductDTO productData){

--- a/src/main/java/com/fernandakipper/desafioanotaai/services/CategoryService.java
+++ b/src/main/java/com/fernandakipper/desafioanotaai/services/CategoryService.java
@@ -6,22 +6,18 @@ import com.fernandakipper.desafioanotaai.domain.category.exceptions.CategoryNotF
 import com.fernandakipper.desafioanotaai.repositories.CategoryRepository;
 import com.fernandakipper.desafioanotaai.services.aws.AwsSnsService;
 import com.fernandakipper.desafioanotaai.services.aws.MessageDTO;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class CategoryService {
 
-    private CategoryRepository repository;
+    private final CategoryRepository repository;
     private final AwsSnsService snsService;
-
-    public CategoryService(CategoryRepository repository, AwsSnsService snsService){
-        this.repository = repository;
-        this.snsService = snsService;
-    }
 
     public Category insert(CategoryDTO categoryData){
         Category newCategory = new Category(categoryData);

--- a/src/main/java/com/fernandakipper/desafioanotaai/services/ProductService.java
+++ b/src/main/java/com/fernandakipper/desafioanotaai/services/ProductService.java
@@ -1,6 +1,5 @@
 package com.fernandakipper.desafioanotaai.services;
 
-import com.fernandakipper.desafioanotaai.domain.category.Category;
 import com.fernandakipper.desafioanotaai.domain.category.exceptions.CategoryNotFoundException;
 import com.fernandakipper.desafioanotaai.domain.product.Product;
 import com.fernandakipper.desafioanotaai.domain.product.ProductDTO;
@@ -8,21 +7,17 @@ import com.fernandakipper.desafioanotaai.domain.product.exceptions.ProductNotFou
 import com.fernandakipper.desafioanotaai.repositories.ProductRepository;
 import com.fernandakipper.desafioanotaai.services.aws.AwsSnsService;
 import com.fernandakipper.desafioanotaai.services.aws.MessageDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class ProductService {
     private final CategoryService categoryService;
     private final ProductRepository repository;
     private final AwsSnsService snsService;
-
-    public ProductService(CategoryService categoryService, ProductRepository productRepository, AwsSnsService snsService){
-        this.categoryService = categoryService;
-        this.repository = productRepository;
-        this.snsService = snsService;
-    }
 
     public Product insert(ProductDTO productData){
         this.categoryService.getById(productData.categoryId())

--- a/src/main/java/com/fernandakipper/desafioanotaai/services/aws/AwsSnsService.java
+++ b/src/main/java/com/fernandakipper/desafioanotaai/services/aws/AwsSnsService.java
@@ -2,22 +2,19 @@ package com.fernandakipper.desafioanotaai.services.aws;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.Topic;
-import org.apache.tomcat.util.json.JSONParser;
-import org.bson.json.JsonObject;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class AwsSnsService {
-    private AmazonSNS snsClient;
-    private Topic catalogTopic;
+    private final AmazonSNS snsClient;
+    @Qualifier("catalogEventsTopic")
+    private final Topic catalogTopic;
 
-    public AwsSnsService(AmazonSNS snsClient, @Qualifier("catalogEventsTopic") Topic catalogTopic){
-        this.snsClient = snsClient;
-        this.catalogTopic = catalogTopic;
-    }
 
-    public void publish(MessageDTO message){
+    public void publish(MessageDTO message) {
         System.out.println(message.message());
         this.snsClient.publish(catalogTopic.getTopicArn(), message.message());
     }


### PR DESCRIPTION
Oi,

Como comentei no primeiro video, acredito que podemos melhorar um pouco a legibilidade do codigo se setarmos as dependencias como `private final` em conjunto com a anotação `@RequiredArgsConstrtor`

Assim, o Lombok gera o construtor com todas as dependencias da classe e o spring consegue injetar.

Extra: adicionei uma config do lombok pra permitir que anotações de `Qualifier` sejam copiadas para o construtor.

Beneficios: Facilita a manutenção e legibilidade do codigo

A principio tudo segue funcionando como antes (baseado nos testes escritos), mas não cheguei a fazer testes manuais para garantir o funcionamento da aplicação

